### PR TITLE
Option to automatically namespace static data

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,15 +1,21 @@
 
-function install(Vue) {
+function install(Vue, options) {
     if (typeof(Vue.config.optionMergeStrategies.static) !== 'function') {
         Vue.config.optionMergeStrategies.static = Vue.config.optionMergeStrategies.data;
+    }
+    // Creates $static instance property if configured
+    // Empty by default
+    if (options && options.namespaced) {
+        Vue.prototype.$static = {};
     }
     Vue.mixin({
         beforeCreate: function () {
             const static = this.$options.static;
+            const destination = this.$static || this;
             if (static && typeof(static) === 'function') {
-                Object.assign(this, static.apply(this));
+                Object.assign(destination, static.apply(this));
             } else if (static && typeof(static) === 'object') {
-                Object.assign(this, static);
+                Object.assign(destination, static);
             }
         },
     });


### PR DESCRIPTION
Expands usage to allow for a single configuration option, `namespaced: boolean`, so that all static data will be namespaced into `$static` component property.

This is solely to avoid conflicts with other options and reactive data (same name, for instance), and helps you to remember which data is or isn't reactive.

Also, tried to add type definitions for TypeScript users, but my knowledge is not enough to extend Vue types.

Example usage with option and namespace:

```js
import VueStatic from 'vue-static';

Vue.use(VueStatic, {
  namespaced: true
});
```

```html
<template>
  <div>
    Reactive data: {{ normalData }}
    Static data: {{ $static.nonChangingValue }}
  </div>
</template>

<script>
export default {
  data() {
    return {
      normalData: 'this will be reactive'
    };
  },
  static() {
    return {
      nonChangingValue: 'this will not'
    };
  }
}
</script>
```